### PR TITLE
Fix shebang for GNU/Linux systems

### DIFF
--- a/bin/rbenv-gemset
+++ b/bin/rbenv-gemset
@@ -1,4 +1,5 @@
-#!/usr/bin/env bash -e
+#!/usr/bin/env bash
+set -e
 
 RBENV_GEMSET_VERSION="0.1.0"
 


### PR DESCRIPTION
Calling rbenv-gemset directly from the command line does not work on GNU/Linux systems:

```
~/rbenv-gemset (git)-[master] % ./bin/rbenv-gemset 
/usr/bin/env: bash -e: No such file or directory
```

`env` can't find a binary named `bash -e`, which it is looking for because arguments on the shebang line are not split up on all systems.

rbenv had the same issue: sstephenson/rbenv#20
