### PR TITLE
Add support for installation to $DESTDIR

### DIFF
--- a/bin/rbenv-gemset
+++ b/bin/rbenv-gemset
@@ -56,6 +56,8 @@ case "$1" in
 "install")
   if [ "$2" == "-g" ]; then
     RBENV_PLUGIN_ROOT=/tmp/rbenv.d
+  elif [ -n $DESTDIR ]; then
+    RBENV_PLUGIN_ROOT=${DESTDIR}
   else
     RBENV_PLUGIN_ROOT="${HOME}/.rbenv/rbenv.d"
   fi


### PR DESCRIPTION
`rbenv-gemset install` should support installation to `$DESTDIR`.

`$DESTDIR` makes staging and packaging much easier.

Most Makefiles support `$DESTDIR` in their install targets, so rbenv-gemset should do the same. See http://www.gnu.org/prep/standards/html_node/DESTDIR.html for reference.
