### PR TITLE
remove -n when checking for existence of DESTDIR

### DIFF
--- a/bin/rbenv-gemset
+++ b/bin/rbenv-gemset
@@ -57,7 +57,7 @@ case "$1" in
 "install")
   if [ "$2" == "-g" ]; then
     RBENV_PLUGIN_ROOT=/etc/rbenv.d
-  elif [ -n $DESTDIR ]; then
+  elif [ -n "$DESTDIR" ]; then
     RBENV_PLUGIN_ROOT=${DESTDIR}
   else
     RBENV_PLUGIN_ROOT="${HOME}/.rbenv/rbenv.d"


### PR DESCRIPTION
Howdy -

When attempting to install rbenv-gemset, I was greeted with this error:

$ rbenv gemset install
mkdir: /exec: Permission denied

It looks like the problem is with this if check:

[ -n $DESTDIR ]

It seemed to be evaluating to true even when the environment variable was not set, and therefore the plugin was attempting to install itself at /. I simple removed the -n because the brackets will evaluate to true if the string is non-empty (see http://tldp.org/LDP/Bash-Beginners-Guide/html/sect_07_01.html).

I'm not sure if this is a best practice, as changing from single [] to double [[]] in the if statement also solved the problem. However, removing the -n solved my problem on bash and zsh.

Thanks,
Drew
