### PR TITLE
Allow gem executables to take precedence

### DIFF
--- a/etc/rbenv.d/which/gemset.bash
+++ b/etc/rbenv.d/which/gemset.bash
@@ -4,12 +4,10 @@ else
   RBENV_GEMSET_ROOT="$(rbenv-prefix)/gemsets"
 fi
 
-if [ ! -x "$RBENV_COMMAND_PATH" ]; then
-  for gemset in $(rbenv-gemset active 2>/dev/null); do
-    command="${RBENV_GEMSET_ROOT}/${gemset}/bin/$RBENV_COMMAND"
-    if [ -x "$command" ]; then
-      RBENV_COMMAND_PATH="$command"
-      break
-    fi
-  done
-fi
+for gemset in $(rbenv-gemset active 2>/dev/null); do
+  command="${RBENV_GEMSET_ROOT}/${gemset}/bin/$RBENV_COMMAND"
+  if [ -x "$command" ]; then
+    RBENV_COMMAND_PATH="$command"
+    break
+  fi
+done


### PR DESCRIPTION
This ensures that gem versions of executables will be run instead of
those in the core Ruby library (ie. rake).
