### PR TITLE
Uses global gemset after local gemset

### DIFF
--- a/libexec/rbenv-gemset-active
+++ b/libexec/rbenv-gemset-active
@@ -3,9 +3,11 @@ set -e
 
 gemset_file="$(rbenv-gemset-file 2>/dev/null || true)"
 
+ACTIVE_GEMSET="global"
+
 if [ -n "$gemset_file" ]; then
-  cat "$gemset_file"
-else
-  echo "no active gemsets" >&2
-  exit 1
+  ACTIVE_GEMSET="$(cat "$gemset_file") $ACTIVE_GEMSET"
 fi
+
+echo $ACTIVE_GEMSET
+


### PR DESCRIPTION
This will force rbenv to always look for gems in the global gemset, but it will use a local one if specified. It works great on my machine. Note, however, there is no easy way to install gems to that gemset at the moment. If you want to try it out you can run `rbenv gemset create global`. Note to install gems you'll have either change your `.rbenv-gemsets` to only point to global then change it back or create a directory with a `.rbenv-gemsets` that has only "global". Then you can switch to that directory to install gems then switch back. I do have a plan for installing, but I don't have time to finish it now. Essentially I'm thinking of implementing an `rbenv gemset install [--gemset name] [--global] NAME` command that will install a gem to the gemset specified. Could the `--gemset` switch be useful for scripting?

What do you all think of this solution? Is there a problem I'm not seeing?
