### PR TITLE
Allow setting the gemsets via the RBENV_GEMSET_NAMES environment var

### DIFF
--- a/libexec/rbenv-gemset-active
+++ b/libexec/rbenv-gemset-active
@@ -3,7 +3,9 @@ set -e
 
 gemset_file="$(rbenv-gemset-file 2>/dev/null || true)"
 
-if [ -n "$gemset_file" ]; then
+if [ -n "$RBENV_GEMSET_NAMES" ]; then
+  echo $RBENV_GEMSET_NAMES
+elif [ -n "$gemset_file" ]; then
   cat "$gemset_file"
 else
   echo "no active gemsets" >&2


### PR DESCRIPTION
To allow me to run programs predictably, I have a script which wraps up rbenv exec and some environment variables. 

``` shell
RBENV_VERSION=1.9.3-p125 RBENV_GEMSET_NAMES=heroku rbenv exec heroku "$@"
```

I'm not sure if it would be useful to be able to have both a `.rbenv-gemsets` file and set the `RBENV_GEMSET_NAMES` environment var. 
