### PR TITLE
Add an option for requiring that gemsets be used

### DIFF
--- a/etc/rbenv.d/exec/gemset.bash
+++ b/etc/rbenv.d/exec/gemset.bash
@@ -18,4 +18,7 @@ done
 
 if [ -n "$GEM_HOME" ]; then
   export GEM_HOME GEM_PATH
+elif [ -n "$RBENV_GEMSET_ENFORCED" ]; then
+  echo "aborting; gemsets are being enforced" >&2
+  exit 1
 fi


### PR DESCRIPTION
I prefer to enforce the use of isolated gem environments. 
This aborts the `rbenv-exec` if no gemsets are defined. 

``` shell
% RBENV_GEMSET_ENFORCED=yes rbenv exec ruby --copyright
aborting; gemsets are being enforced
```

I am not sure if it should be possible to set this to `no` and for the feature to be disabled. 

``` shell
% RBENV_GEMSET_ENFORCED=no rbenv exec ruby --copyright
ruby - Copyright (C) 1993-2011 Yukihiro Matsumoto
```
