### PR TITLE
displaying link to readme at help output

### DIFF
--- a/libexec/rbenv-gemset
+++ b/libexec/rbenv-gemset
@@ -60,6 +60,8 @@ if [ -z "$command_path" ]; then
     echo "  file"
     echo "  list"
     echo "  version"
+    echo
+    echo "For full documentation, see: https://github.com/jamis/rbenv-gemset#readme"
   } >&2
   exit 1
 fi


### PR DESCRIPTION
It adds the following line to the help output:

> For full documentation, see: https://github.com/jamis/rbenv-gemset#readme
