### PR TITLE
displaying an error message when the gemset does not exist

### DIFF
--- a/libexec/rbenv-gemset-delete
+++ b/libexec/rbenv-gemset-delete
@@ -8,5 +8,12 @@ if [ -z "$RBENV_VERSION" ] || [ -z "$RBENV_GEMSET" ]; then
   exit 1
 fi
 
-rm -rf "$(rbenv prefix "$RBENV_VERSION")/gemsets/$RBENV_GEMSET"
+GEMSET_PATH="$(rbenv prefix "$RBENV_VERSION")/gemsets/$RBENV_GEMSET"
+
+if [ ! -d $GEMSET_PATH ]; then
+  echo "couldn't delete ${RBENV_GEMSET} from ${RBENV_VERSION}. Check if it exists"
+  exit 1
+fi
+
+rm -rf $GEMSET_PATH
 echo "deleted ${RBENV_GEMSET} from ${RBENV_VERSION}"


### PR DESCRIPTION
When the user tries to delete a non-existent gemset, then this message is displayed:

> couldn't delete no_no_no from 1.9.2-p290. Check if it exists
