### PR TITLE
Support completions of subcommands

### DIFF
--- a/libexec/rbenv-gemset
+++ b/libexec/rbenv-gemset
@@ -5,16 +5,24 @@ RBENV_GEMSET_VERSION="0.3.0"
 
 # Provide rbenv completions
 if [ "$1" = "--complete" ]; then
-  echo "active"
-  echo "create"
-  echo "delete"
-  echo "file"
-  echo "list"
-  echo "version"
-  exit
+  if [ -z "$2" ]; then
+    echo "active"
+    echo "create"
+    echo "delete"
+    echo "file"
+    echo "list"
+    echo "version"
+    exit
+  else
+    gemset_completion=1
+    shift
+  fi
 fi
 
 if [ "$1" = "version" ] || [ "$1" = "--version" ]; then
+  if [ -z "$gemset_completion" ]; then
+    exit
+  fi
   echo "rbenv-gemset ${RBENV_GEMSET_VERSION}"
   echo "by Jamis Buck <jamis@jamisbuck.org>"
   echo "http://github.com/jamis/rbenv-gemset"
@@ -67,4 +75,8 @@ if [ -z "$command_path" ]; then
 fi
 
 shift
-exec "$command_path" "$@"
+if [ -n "$gemset_completion" ] && grep -i "^# provide rbenv completions" "$command_path" >/dev/null; then
+  exec "$command_path" --complete "$@"
+elif [ -z "$gemset_completion" ]; then
+  exec "$command_path" "$@"
+fi

--- a/libexec/rbenv-gemset-create
+++ b/libexec/rbenv-gemset-create
@@ -1,6 +1,14 @@
 #!/usr/bin/env bash
 set -e
 
+# Provide rbenv completions
+if [ "$1" = "--complete" ]; then
+  if [ -z "$2" ]; then
+    exec rbenv-versions --bare
+  fi
+  exit
+fi
+
 RBENV_VERSION="$1"
 if [ -z "$RBENV_VERSION" ]; then
   { echo "you must specify an installed version to associate the gemset with"

--- a/libexec/rbenv-gemset-delete
+++ b/libexec/rbenv-gemset-delete
@@ -1,6 +1,24 @@
 #!/usr/bin/env bash
 set -e
 
+# Provide rbenv completions
+if [ "$1" = "--complete" ]; then
+  if [ -z "$2" ]; then
+    exec rbenv-versions --bare
+  elif [ -z "$3" ]; then
+    shopt -s nullglob
+    gemsets=($(rbenv prefix "$2")/gemsets/*)
+    shopt -u nullglob
+
+    if [ -n "$gemsets" ]; then
+      for gemset in ${gemsets[@]}; do
+        echo "${gemset##*/}"
+      done
+    fi
+  fi
+  exit
+fi
+
 RBENV_VERSION="$1"
 RBENV_GEMSET="$2"
 if [ -z "$RBENV_VERSION" ] || [ -z "$RBENV_GEMSET" ]; then


### PR DESCRIPTION
With this change gemset subcommands will also support completion of their arguments.

What it does is simply passing the --complete argument on to the subcommand if the subcommand contains the comment `# Provide rbenv completions` like rbenv-completions does.

There is one small snag with this change in that it wont work without this: https://github.com/sstephenson/rbenv/pull/267

You can test it in action with a command like `rbenv completions gemset create` 
