### PR TITLE
Only add `global` to gemsets when specified is not `global`.

### DIFF
--- a/libexec/rbenv-gemset-active
+++ b/libexec/rbenv-gemset-active
@@ -7,7 +7,12 @@ if [ -n "$RBENV_GEMSETS" ]; then
   echo $RBENV_GEMSETS
 elif [ -n "$gemset_file" ]; then
   RBENV_GEMSETS="global"
-  RBENV_GEMSETS="$(cat "$gemset_file") $RBENV_GEMSETS"
+  specified_gemset=$(cat $gemset_file)
+  if [[ "$specified_gemset" =~ "\bglobal\b" ]]; then
+    RBENV_GEMSETS=$specified_gemset
+  else
+    RBENV_GEMSETS="$specified_gemset $RBENV_GEMSETS"
+  fi
   echo $RBENV_GEMSETS
 else
   echo "no active gemsets" >&2


### PR DESCRIPTION
- If I specified `global` in .rbenv-gemsets is the gemset
  what I want to use, then `rbenv gemset active` will output
  `global global`. We should consider this situation.
