### PR TITLE
Add special __DEFAULT__ gemset to include all default gems

### DIFF
--- a/etc/rbenv.d/exec/gemset.bash
+++ b/etc/rbenv.d/exec/gemset.bash
@@ -16,7 +16,11 @@ for gemset in $(rbenv-gemset active 2>/dev/null); do
     if [ -z "$GEM_HOME" ]; then
       GEM_HOME="$path"
     fi
-    GEM_PATH="$GEM_PATH:$path"
+    if [ -z "$GEM_PATH" ]; then
+      GEM_PATH=$path
+    else
+      GEM_PATH="$GEM_PATH:$path"
+    fi
   fi
 done
 


### PR DESCRIPTION
"Global" gemset is not used when no gemset is active.
A rbenv user usually installs gems into the default directory, not "global" gemset.
This option make it easy to reuse these gems in the default directory.

Current implementation get gempath by

```
RBENV_GEMSETS=" " gem env gempath
```

but it is ugly.  Please modify if there is a better way

Example:

```
# .rbenv-gemsets
my-gemset
__DEFAULT__
```
