### PR TITLE
able to use .ruby-gemset file for the application level gemset

### DIFF
--- a/libexec/rbenv-gemset-file
+++ b/libexec/rbenv-gemset-file
@@ -7,6 +7,9 @@ if [ -z "$RBENV_GEMSET_FILE" ]; then
     if [ -e "${root}/.rbenv-gemsets" ]; then
       RBENV_GEMSET_FILE="${root}/.rbenv-gemsets"
       break
+    elif [ -e "${root}/.ruby-gemset" ]; then
+      RBENV_GEMSET_FILE="${root}/.ruby-gemset"
+      break
     fi
     root="${root%/*}"
   done


### PR DESCRIPTION
For some ruby version manager like rvm, they use .ruby-gemset instead of .rbenv-gemsets. These code is to load .ruby-gemset if no .rbenv-gemsets file found.
