### PR TITLE
add [gemset] option to gemset active command (like rbenv local command)

### DIFF
--- a/libexec/rbenv-gemset
+++ b/libexec/rbenv-gemset
@@ -62,7 +62,7 @@ if [ -z "$command_path" ]; then
     echo "${0##*/} [command] [options]"
     echo
     echo "possible commands are:"
-    echo "  active"
+    echo "  active [gemset]"
     echo "  create [version] [gemset]"
     echo "  delete [version] [gemset]"
     echo "  file"

--- a/libexec/rbenv-gemset-active
+++ b/libexec/rbenv-gemset-active
@@ -1,6 +1,15 @@
 #!/usr/bin/env bash
 set -e
 
+# activete
+if [ $# -eq 1 ]; then
+  ARG_GEMSETS=$1
+  gemset_file=$(pwd)/.rbenv-gemsets
+  echo $ARG_GEMSETS > $gemset_file 
+  echo "activate $ARG_GEMSETS gemset ($gemset_file)"
+  exit
+fi
+
 gemset_file="$(rbenv-gemset-file 2>/dev/null || true)"
 
 if [ -n "$RBENV_GEMSETS" ]; then


### PR DESCRIPTION
I offen forget '.rbenv-gemsets' filename. so implement this patche.

if run "gemset active <gemset>", create .rbenv-gemsets and put <gemset> in it.
if "gemset active", show active gemsets (same as it was)
#### usage

``` sh
$ rbenv gemset active FOO
activate FOO gemset (/Users/t-koshiba/dev/rbenv-gemset/.rbenv-gemsets)
$ rbenv gemset active
FOO
$ ls .rbenv-gemsets 
.rbenv-gemsets
```
