### PR TITLE
bump version number to 0.4.0

### DIFF
--- a/libexec/rbenv-gemset
+++ b/libexec/rbenv-gemset
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -e
 
-RBENV_GEMSET_VERSION="0.3.0"
+RBENV_GEMSET_VERSION="0.4.0"
 
 # Provide rbenv completions
 if [ "$1" = "--complete" ]; then


### PR DESCRIPTION
homebrew is installing a 2 year old version of `rbenv-gemset` which is lacking awesome features like:
- bash completion for subcommands
- the use of `.ruby-version`
- the super handy `RBENV_GEMSET_FILE` env variable

In order to fix the `homebrew` formula, I need there to be a git tag pointing to how awesome this plugin is right now.

This pull request bumps the version number stored in `bin/rbenv-gemset`. I also added a tag to my fork, but am not 100% certain this will get dragged along with the pull request.

Thanks!
