### PR TITLE
Fix: append default GEM_PATH

### DIFF
--- a/etc/rbenv.d/exec/gemset.bash
+++ b/etc/rbenv.d/exec/gemset.bash
@@ -28,7 +28,8 @@ done
 IFS="$OLDIFS"
 
 RUBY_BIN=$(rbenv which ruby)
-DEFAULT_GEM_PATH=$(command "$RUBY_BIN" -r rubygems -e 'puts Gem.path.join(":")')
+RUBY_SCRIPT='puts Gem.path.grep(/versions/).join(":")'
+DEFAULT_GEM_PATH=$(command "$RUBY_BIN" -r rubygems -e "$RUBY_SCRIPT")
 GEM_PATH="$GEM_PATH:$DEFAULT_GEM_PATH"
 
 if [ -n "$GEM_HOME" ]; then


### PR DESCRIPTION
Although only two gems in jruby(rake and jruby-launcher), jruby suffer the same problem.
I have tested it in jruby-1.7.6 and jruby-1.7.8

I think the better way for this issue is adding the default gem path back.
