### PR TITLE
Fix: append default GEM_PATH

### DIFF
--- a/etc/rbenv.d/exec/gemset.bash
+++ b/etc/rbenv.d/exec/gemset.bash
@@ -11,12 +11,10 @@ project_gemset='\..+'
 OLDIFS="$IFS"
 IFS=$' \t\n'
 
-RUBY_BIN=$(rbenv which ruby)
-DEFAULT_GEM_PATH=$(command "$RUBY_BIN" -e "puts Gem.path.grep(/versions/).first")
-
 for gemset in $(rbenv-gemset active 2>/dev/null); do
   if [ $gemset = "__DEFAULT__" ];then
-    GEM_PATH="$GEM_PATH:$DEFAULT_GEM_PATH"
+    RUBY_BIN=$(rbenv which ruby)
+    DEFAULT_GEM_PATH=$(command "$RUBY_BIN" -e "puts Gem.path.grep(/versions/).first")
     continue
   fi
 
@@ -35,6 +33,8 @@ for gemset in $(rbenv-gemset active 2>/dev/null); do
   fi
 done
 IFS="$OLDIFS"
+
+[ -n $DEFAULT_GEM_PATH ] && GEM_PATH=$GEM_PATH:$DEFAULT_GEM_PATH
 
 if [ -n "$GEM_HOME" ]; then
   export GEM_HOME GEM_PATH PATH


### PR DESCRIPTION
I have tested it on jruby 1.7.6 and 1.6.8 also. they suffer the same issue.
Although jruby just has two default gems(jruby-launcher and rake).

I think the best way is add the default GEM_PATH back.
And I also try to remove the .gem in GEM_PATH
