### PR TITLE
Fixed duplicated "global" gemset when using `rbenv gemset active` with bash-3.2

### DIFF
--- a/libexec/rbenv-gemset-active
+++ b/libexec/rbenv-gemset-active
@@ -7,7 +7,7 @@ if [ -n "$RBENV_GEMSETS" ]; then
   echo $RBENV_GEMSETS
 elif [ -n "$gemset_file" ]; then
   RBENV_GEMSETS=$(cat "$gemset_file")
-  if echo $RBENV_GEMSETS | grep -v "\bglobal\b" > /dev/null 2>&1; then
+  if echo $RBENV_GEMSETS | grep -v '\bglobal\b' >/dev/null 2>&1; then
     RBENV_GEMSETS="$RBENV_GEMSETS global"
   fi
   echo $RBENV_GEMSETS


### PR DESCRIPTION
667e17fdd0fcbec3a061fe6f8ba323f2c3dad641 didn't work for me, "global" was still appended when .rbenv-gemsets already included it (my computer was running bash 3.2).
