### PR TITLE
Feature rbenv gemset options

### DIFF
--- a/etc/rbenv.d/exec/gemset.bash
+++ b/etc/rbenv.d/exec/gemset.bash
@@ -30,7 +30,7 @@ for gemset in $(rbenv-gemset active 2>/dev/null); do
 done
 IFS="$OLDIFS"
 
-if [[ "$(rbenv-gemset active 2>/dev/null)" =~ (\ |^)global($|\ ) ]]; then
+if [ "$(rbenv-gemset option exclude-default-gempath)" != "yes" ]; then
   GEM_PATH="$GEM_PATH:$("$(rbenv which gem)" env gemdir)"
 fi
 

--- a/libexec/rbenv-gemset
+++ b/libexec/rbenv-gemset
@@ -11,6 +11,8 @@ if [ "$1" = "--complete" ]; then
     echo "create"
     echo "delete"
     echo "file"
+    echo "optionfile"
+    echo "option"
     echo "list"
     echo "version"
     exit
@@ -70,6 +72,8 @@ if [ -z "$command_path" ]; then
     echo "  delete [version] [gemset]"
     echo "  file"
     echo "  init [gemset]"
+    echo "  optionfile"
+    echo "  option [option]"
     echo "  list"
     echo "  version"
     echo

--- a/libexec/rbenv-gemset-active
+++ b/libexec/rbenv-gemset-active
@@ -7,6 +7,12 @@ if [ -n "$RBENV_GEMSETS" ]; then
   echo $RBENV_GEMSETS
 elif [ -n "$gemset_file" ]; then
   RBENV_GEMSETS=$(cat "$gemset_file")
+  if [ "$(rbenv-gemset-option disable-global-gemset)" != "yes" ]; then
+    has_global='\bglobal\b'
+    if [[ ! $RBENV_GEMSETS =~ $has_global ]]; then
+      RBENV_GEMSETS="$RBENV_GEMSETS global"
+    fi
+  fi
   echo $RBENV_GEMSETS
 else
   echo "no active gemsets" >&2

--- a/libexec/rbenv-gemset-option
+++ b/libexec/rbenv-gemset-option
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -e
+
+if [ -n "$1" ]; then
+  GEMSET_OPTION_FILE="$(rbenv-gemset-optionfile || true)"
+  if [ -n "$GEMSET_OPTION_FILE" ]; then
+    RBENV_GEMSET_OPTION=$(grep -m 1 ^$1= "$GEMSET_OPTION_FILE" | head -1 | sed "s/^$1=//" || true)
+    if [ -n "$RBENV_GEMSET_OPTION" ]; then
+      echo "$RBENV_GEMSET_OPTION"
+    fi
+  fi
+fi

--- a/libexec/rbenv-gemset-optionfile
+++ b/libexec/rbenv-gemset-optionfile
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -e
+
+if [ -z "$RBENV_GEMSET_OPTION_FILE" ]; then
+  root="$(pwd)"
+  while [ -n "$root" ]; do
+    if [ -e "${root}/.rbenv-gemset-options" ]; then
+      RBENV_GEMSET_OPTION_FILE="${root}/.rbenv-gemset-options"
+      break
+    fi
+    root="${root%/*}"
+  done
+fi
+
+if [ -e "$RBENV_GEMSET_OPTION_FILE" ]; then
+  echo "$RBENV_GEMSET_OPTION_FILE"
+  exit
+fi
+
+exit 1


### PR DESCRIPTION
### Added option file and option parsing:
- rbenv-gemset now can use an option file `.rbenv-gemset-options`
- the option file can contain options in the following form:

```
this-is-an-option=value
this-is-another-option=another_value
```
- new command: `rbenv-gemset-optionfile` which returns an option file (similar to rbenv-gemset-file)
- new command: `rbenv-gemset-option <optionname>` which returns the value of the option if set in an option file, if option is not set, it will return an empty string
### Added options which can be set in option file:
- `disable-global-gemset=yes` this will disable the automatic usage of the `global` gemset
- `exclude-default-gempath=yes` this will disable the usage of the default gem path, resulting in an minimal gemset and using only the gems included in your Ruby and gemsets you added via rbenv-gemset
