### PR TITLE
Fixed gemset list if $RBENV_ROOT was not set.

### DIFF
--- a/libexec/rbenv-gemset-list
+++ b/libexec/rbenv-gemset-list
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -e
 
-for version in "$RBENV_ROOT"/versions/*; do
+for version in "$(rbenv root)"/versions/*; do
   shopt -s nullglob
   gemsets=("$version"/gemsets/* "$version"/gemsets/.project-gemsets/*)
   shopt -u nullglob


### PR DESCRIPTION
There was an issue where $RBENV_ROOT is not set, and the list script did not work. The rbenv project added their own function to find the root which was added in place of just the $RBENV_ROOT env var. This passes off the function of finding this root to rbenv and allows rbenv-gemset list to work in both instances now.
