### PR TITLE
fix conditions for project gemset

### DIFF
--- a/etc/rbenv.d/exec/gemset.bash
+++ b/etc/rbenv.d/exec/gemset.bash
@@ -10,7 +10,7 @@ else
 fi
 
 RBENV_GEMSET_DIR="$(dirname "$(rbenv-gemset file 2>/dev/null)" 2>/dev/null)"
-project_gemset='\..+'
+project_gemset='^\..+'
 OLDIFS="$IFS"
 IFS=$' \t\n'
 for gemset in $(rbenv-gemset active 2>/dev/null); do

--- a/etc/rbenv.d/rehash/gemset.bash
+++ b/etc/rbenv.d/rehash/gemset.bash
@@ -2,7 +2,7 @@ shopt -s nullglob
 
 RBENV_GEMSET_DIR="$(dirname "$(rbenv-gemset file 2>/dev/null)" 2>/dev/null)"
 PROJECT_GEMSET_LIST="${RBENV_ROOT}/versions/$(rbenv-version-name)/gemsets/.project-gemsets"
-project_gemset='\..+'
+project_gemset='^\..+'
 OLDIFS="$IFS"
 IFS=$' \t\n'
 for gemset in $(rbenv-gemset active 2>/dev/null); do

--- a/etc/rbenv.d/which/gemset.bash
+++ b/etc/rbenv.d/which/gemset.bash
@@ -5,7 +5,7 @@ else
 fi
 
 RBENV_GEMSET_DIR="$(dirname "$(rbenv-gemset file 2>/dev/null)" 2>/dev/null)"
-project_gemset='\..+'
+project_gemset='^\..+'
 OLDIFS="$IFS"
 IFS=$' \t\n'
 for gemset in $(rbenv-gemset active 2>/dev/null); do


### PR DESCRIPTION
When gemset name has a '.'(dot) after the 2nd character, it is project gemset.
Insted it might want to be common gemset.

For example: 
$ echo 'example.1' > .rbenv-gemsets
$ gem env
...
- GEM PATHS:
  - /path/tp/project/example.1
  - /usr/local/rbenv/versions/2.1.2/gemsets/global
    ...

I hope for:
$ gem env
...
- GEM PATHS:
  - /usr/local/rbenv/versions/2.1.2/gemsets/example.1
  - /usr/local/rbenv/versions/2.1.2/gemsets/global
    ...
