### PR TITLE
rbenv-gemset-create: show error on system ruby

### DIFF
--- a/libexec/rbenv-gemset-create
+++ b/libexec/rbenv-gemset-create
@@ -16,6 +16,9 @@ if [ -z "$RBENV_VERSION" ]; then
     rbenv versions
   } >&2
   exit 1
+elif [ "$RBENV_VERSION" = "system" ]; then
+  echo "you can only create gemset for ruby installed by rbenv." >&2
+  exit 1
 fi
 
 rbenv prefix "$RBENV_VERSION" > /dev/null # make sure the provided version exists


### PR DESCRIPTION
Show error when trying to create gemset for ruby
installed by the system.
Closes #88

This is my first bash pull request, tested it on my machine and works.
I use brew, and edit the file from my system to create this patch.

Let me know if i'm doing it wrong.