### PR TITLE
Update README, Github no longer allows git:// operations

### DIFF
--- a/README.mkd
+++ b/README.mkd
@@ -41,7 +41,7 @@ a.k.a. "How To Ask Questions The Smart Way"
 
 Download and extract the [latest release](https://github.com/jf/rbenv-gemset/releases/latest) (v0.5.9 now!) or clone rbenv-gemset to your `$HOME/.rbenv/plugins` directory:
 
-    $ git clone git://github.com/jf/rbenv-gemset.git $HOME/.rbenv/plugins/rbenv-gemset
+    $ git clone https://github.com/jf/rbenv-gemset.git $HOME/.rbenv/plugins/rbenv-gemset
 
 ### Homebrew
 


### PR DESCRIPTION
Github deprecated git:// operations, quick fix
https://github.blog/2021-09-01-improving-git-protocol-security-github/